### PR TITLE
Fix TRT8 AttributeError: 'tensorrt.tensorrt.Builder' object has no attribute 'int8_calibrator'

### DIFF
--- a/torch2trt_dynamic/torch2trt_dynamic.py
+++ b/torch2trt_dynamic/torch2trt_dynamic.py
@@ -584,7 +584,7 @@ def torch2trt_dynamic(module,
         config.set_calibration_profile(profile)
         if version.parse(trt.__version__) < version.parse('8'):
             builder.int8_mode = int8_mode
-        builder.int8_calibrator = config.int8_calibrator
+            builder.int8_calibrator = config.int8_calibrator
 
     engine = builder.build_engine(network, config)
 


### PR DESCRIPTION
Fix #22, TRT8 AttributeError: 'tensorrt.tensorrt.Builder' object has no attribute 'int8_calibrator'.